### PR TITLE
Update library properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
-name=ServoESP32
+name=ESP32ArduinoServo
 version=1.0.1
 author=Jaroslav Paral
 maintainer=Jaroslav Paral <paral@robotikabrno.cz>
 sentence=Generate RC servo signal on a selected pin.
 paragraph=
 category=Device Control
-url=http://arduino.cc/en/Reference/Servo
+url=https://github.com/RoboticsBrno/ESP32-Arduino-Servo-Library
 architectures=esp32


### PR DESCRIPTION
Update the library URL to point to the actual library and not the default Arduino one and select a more unique name so to avoid conflicts with another ESP32Servo library in Arduino IDE's library manager.

Can you also please consider adding this great work of yours to the Arduino IDE library manager? It would make my life much easier. :)

You can do this by [following these instructions](https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ#how-can-i-add-my-library-to-library-manager).